### PR TITLE
Automate Decision Doc Integration

### DIFF
--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -32,28 +32,43 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
 
-    - name: Extract filename and decision type from issue title
+    - name: Extract subject and category from issue title
       id: extract_info
       run: |
-        echo "::set-output name=fileName::$(echo '${{ github.event.issue.title }}' | awk -F'[()]' '{split($2,a,","); print a[1]}'"
-        echo "::set-output name=decisionType::$(echo '${{ github.event.issue.title }}' | awk -F'[()]' '{split($2,a,","); print a[2]}'"
-
+        title="${{ github.event.issue.title }}"
+        if [[ "$title" =~ ^Opening\ decision\ on\ ([^/]+)(/([^/]+))?$ ]]; then
+          subject=$(echo "${BASH_REMATCH[1]}" | tr -d ' ')
+          category=$(echo "${BASH_REMATCH[3]}" | tr -d ' ')
+          if [[ -z "$category" ]]; then
+            category=""
+          fi
+          echo "::set-output name=subject::$subject"
+          echo "::set-output name=category::$category"
+        else
+          echo "Issue title does not follow the required format: 'Opening decision on [category]/[subject]'"
+          exit 1
+        fi
     - name: Create new branch
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git checkout -b "issue-${{ github.event.issue.number }}"
-        
+        git checkout -b "docs/${{ github.event.issue.number }}_decision-${{ steps.extract_info.outputs.fileName }}"
+
+        # Determine the directory structure
+        if [[ -z "${{ steps.extract_info.outputs.category }}" ]]; then
+          dir_path="docs/decisions"
+        else
+          dir_path="docs/decisions/${{ steps.extract_info.outputs.category }}"
+        fi
+
         # Create the directory structure for the documentation
-        mkdir -p docs/${{ steps.extract_info.outputs.decisionType }}/${{ steps.extract_info.outputs.fileName }}
+        mkdir -p "$dir_path"
         
-        # Create a new.md file with the issue's body as content
-        echo "${{ github.event.issue.body }}" > docs/${{ steps.extract_info.outputs.decisionType }}/${{ steps.extract_info.outputs.fileName }}.md
-        
-        git lfs track "*.md" # Track markdown files if they are large
-        git add.
-        git commit -m "Add documentation for ${{ github.event.issue.title }}"
-        git push origin "docs/${{ github.event.issue.number }}_decision-${{ steps.extract_info.outputs.fileName }}"
+        # Create a new markdown file with the issue's body as content
+        echo "${{ github.event.issue.body }}" > "$dir_path/${{ steps.extract_info.outputs.subject }}_DECISION.md"
+        git add .
+        git commit -m "${{ github.event.issue.title }}"
+        git push origin "docs/${{ github.event.issue.number }}_decision-${{ steps.extract_info.outputs.subject }}"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -1,0 +1,49 @@
+name: Create Branch and PR from Issue Label
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  create_branch_and_pr:
+    if: github.event.label.name == 'decision'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Extract filename and decision type from issue title
+      id: extract_info
+      run: |
+        echo "::set-output name=fileName::$(echo '${{ github.event.issue.title }}' | awk -F'[()]' '{split($2,a,","); print a[1]}'"
+        echo "::set-output name=decisionType::$(echo '${{ github.event.issue.title }}' | awk -F'[()]' '{split($2,a,","); print a[2]}'"
+
+    - name: Create new branch
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git checkout -b "issue-${{ github.event.issue.number }}"
+        
+        # Create the directory structure for the documentation
+        mkdir -p docs/${{ steps.extract_info.outputs.decisionType }}/${{ steps.extract_info.outputs.fileName }}
+        
+        # Create a new.md file with the issue's body as content
+        echo "${{ github.event.issue.body }}" > docs/${{ steps.extract_info.outputs.decisionType }}/${{ steps.extract_info.outputs.fileName }}.md
+        
+        git lfs track "*.md" # Track markdown files if they are large
+        git add.
+        git commit -m "Add documentation for ${{ github.event.issue.title }}"
+        git push origin "docs/${{ github.event.issue.number }}_decision-${{ steps.extract_info.outputs.fileName }}"
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Add documentation for decision: ${{ github.event.issue.title }}"
+        title: "Automated PR for issue ${{ github.event.issue.number }}"
+        labels: "automerge"
+        body: "This PR was automatically created to document the issue."

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Triggering user is unauthorized."
           exit 1
         fi
-    - name: Check out code
+    - name: Checkout
       uses: actions/checkout@v3
 
     - name: Extract subject and category from issue title

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -75,6 +75,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Add documentation for decision: ${{ github.event.issue.title }}"
-        title: "${{ github.event.issue.title }}"
+        title: "Automated PR ${{ github.event.issue.title }}"
         labels: "automerge"
         body: "This PR was automatically created to document ${{ github.event.issue.number }}."

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -75,6 +75,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Add documentation for decision: ${{ github.event.issue.title }}"
-        title: "Automated PR for issue ${{ github.event.issue.number }}"
+        title: "${{ github.event.issue.title }}"
         labels: "automerge"
         body: "This PR was automatically created to document the issue."

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -77,4 +77,4 @@ jobs:
         commit-message: "Add documentation for decision: ${{ github.event.issue.title }}"
         title: "${{ github.event.issue.title }}"
         labels: "automerge"
-        body: "This PR was automatically created to document the issue."
+        body: "This PR was automatically created to document ${{ github.event.issue.number }}."

--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -13,6 +13,22 @@ jobs:
       pull-requests: write
 
     steps:
+    - name: Authorization
+      run: |
+        # Get username of GitHub account that triggered this flow
+        opener=${{ github.actor }}
+        
+        # Get list of approved contributors
+        contributors=$(curl https://api.github.com/repos/Monstarrrr/Rebutify/contributors | jq -r '[.[] | select(.type == "User") | .login] | join(",")')
+        
+        # Convert the comma-separated string to an array
+        IFS=',' read -r -a contributor_array <<< "$contributors"
+
+        # Check if triggering user is in the array
+        if [[ ! " ${contributor_array[@]} " =~ " $opener " ]]; then
+          echo "Triggering user is unauthorized."
+          exit 1
+        fi
     - name: Check out code
       uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR adds a github actions workflow that automates integrating new decisions into the docs/ folder.

Whenever a issue is tagged as "decision", it makes a new branch, puts the issue body into a folder based on the issue title, and creates a PR.

The issue titles for decisions must be of the form "lorem ipsum (fileName, decisionType)" and contain no other parentheses.