### PR TITLE
Change Site Domain to Frontend URL

### DIFF
--- a/backend/.template-env
+++ b/backend/.template-env
@@ -15,6 +15,8 @@ STAGE=local
 DJANGO_ADMIN_PATH=admin/
 # Hostnames, comma separated
 DJANGO_HOSTS=localhost,127.0.0.1
+# URL of frontend
+FRONTEND_SITE_URL=localhost:3000
 
 # Uses a local SQLite DB
 DEBUG_DB=True

--- a/backend/rebutify/settings.py
+++ b/backend/rebutify/settings.py
@@ -38,6 +38,7 @@ ALLOWED_HOSTS: List[str] = (
     else ["localhost", "127.0.0.1"]
 )
 
+SITE_URL = os.getenv("FRONTEND_SITE_URL", "localhost:3000")
 
 # Application definition
 

--- a/backend/rebutify/settings.py
+++ b/backend/rebutify/settings.py
@@ -39,6 +39,7 @@ ALLOWED_HOSTS: List[str] = (
 )
 
 SITE_URL = os.getenv("FRONTEND_SITE_URL", "localhost:3000")
+SITE_ID = 1
 
 # Application definition
 
@@ -49,6 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     "corsheaders",
     "core",
     "rest_framework",

--- a/backend/rebutify/settings.py
+++ b/backend/rebutify/settings.py
@@ -38,7 +38,9 @@ ALLOWED_HOSTS: List[str] = (
     else ["localhost", "127.0.0.1"]
 )
 
+# URL used in activation, password reset emails, etc.
 SITE_URL = os.getenv("FRONTEND_SITE_URL", "localhost:3000")
+
 SITE_ID = 1
 
 # Application definition

--- a/backend/scripts/update_site_domain.py
+++ b/backend/scripts/update_site_domain.py
@@ -1,0 +1,13 @@
+# Script to update the domain Django thinks it's
+# running on.
+# This is the URL sent in activation emails.
+#
+# To run this script, pipe it into the Django shell.
+# python manage.py shell < [this file]
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+site = Site.objects.get(id=1)
+site.domain = settings.SITE_URL
+site.save()

--- a/backend/scripts/update_site_domain.py
+++ b/backend/scripts/update_site_domain.py
@@ -8,6 +8,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 
-site = Site.objects.get(id=1)
+site = Site.objects.get(id=settings.SITE_ID)
 site.domain = settings.SITE_URL
 site.save()


### PR DESCRIPTION
These changes introduce
- the ability to change the base URL in activation emails
- a convenience script to do so
- new changes to .template-env

The site domain is stored only in the **database** and is not decided by the **application**.