### PR TITLE
fix: pass "branch" to create-pull-request action

### DIFF
--- a/.github/workflows/decision.yml
+++ b/.github/workflows/decision.yml
@@ -87,3 +87,4 @@ jobs:
           title: 'Automated PR ${{ github.event.issue.title }}'
           labels: 'documentation,decision'
           body: 'This PR was automatically created to document ${{ github.event.issue.number }}.'
+          branch: 'docs/${{ github.event.issue.number }}_decision-$subject'


### PR DESCRIPTION
#141
Passed the branch name to the action so that it doesn't use its own default branch name as in the failed pipeline run in #141.