### PR TITLE
fixed the frontend posts.map issue

### DIFF
--- a/frontend/app/_api/posts/getPosts.ts
+++ b/frontend/app/_api/posts/getPosts.ts
@@ -3,7 +3,7 @@ import api from '@/api/api'
 export const getPosts = async () => {
   try {
     const response = await api.get('api/posts/')
-    return response.data
+    return response.data.results
   } catch (error: any) {
     console.error(
       '# "Get posts" request failed: ',


### PR DESCRIPTION
changed getPosts to return response.data.results instead of response.data

calling api/posts return response where response.data = an object with the array of posts. before was only the array. we don't know why that happened. we will look into that.

EDIT:
the object is for pagination with values for "next" and "previous" for the page links and "results" for the array (of posts).