### PR TITLE
More options for setting the allowed origins during local debugging 

### DIFF
--- a/backend/rebutify/settings.py
+++ b/backend/rebutify/settings.py
@@ -88,6 +88,8 @@ CORS_ALLOWED_ORIGINS = [
     "http://0.0.0.0:3000",
     "http://127.0.0.1:3000",
 ]
+if DEBUG:
+    CORS_ALLOWED_ORIGINS += ["http://" + host for host in ALLOWED_HOSTS]
 
 # Normalizing URLs for front-end (https://docs.djangoproject.com/en/4.0/ref/middleware/#django.middleware.common.CommonMiddleware)
 APPEND_SLASH = True


### PR DESCRIPTION
optionally set the frontend url/ip in debug mode to avoid cors errors
input comma separated to DJANGO_HOSTS=